### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you’re using [Carthage](http://github.com/Carthage/Carthage), add EmojiKit 
 github "dasmer/EmojiKit"
 ```
 
-Otherwise, if you're using [Cocoapods](http://cocoapods.org), add EmojiKit to your `Podfile`:
+Otherwise, if you're using [CocoaPods](http://cocoapods.org), add EmojiKit to your `Podfile`:
 
 ```ruby
 pod 'EmojiKit', '~> 0.0.1'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
